### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,4 +1,6 @@
 name: Type Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ziquid/zds-ai-cli/security/code-scanning/1](https://github.com/ziquid/zds-ai-cli/security/code-scanning/1)

To fix the issue, set an explicit `permissions` block in the workflow YAML file to reduce the `GITHUB_TOKEN` privileges to the minimum needed. Since the workflow only checks out code, installs dependencies, and runs a typecheck, it only requires read access to the repository contents. Thus, add a `permissions` key at the workflow or job level, with `contents: read`. The best practice is to define this at the top level (just below the workflow name), so it applies to all jobs unless overridden. Edit `.github/workflows/typecheck.yml` to insert a `permissions:` block below the workflow name and above `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
