### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -397,6 +397,14 @@ export class GrokClient {
       role: "user",
       content: query,
     };
+
+    const searchOptions: SearchOptions = {
+      search_parameters: searchParameters || { mode: "on" },
+    };
+
+    return this.chat([searchMessage], [], undefined, searchOptions);
+  }
+
   /**
    * Returns true if the host part of baseURL matches one of the allowedHosts or a subdomain thereof.
    */
@@ -409,12 +417,5 @@ export class GrokClient {
     } catch (e) {
       return false;
     }
-  }
-
-    const searchOptions: SearchOptions = {
-      search_parameters: searchParameters || { mode: "on" },
-    };
-
-    return this.chat([searchMessage], [], undefined, searchOptions);
   }
 }

--- a/src/grok/client.ts
+++ b/src/grok/client.ts
@@ -274,9 +274,10 @@ export class GrokClient {
 
     // Only add think parameter for backends that support it (Grok, Ollama)
     const backendLower = this.backendName.toLowerCase();
+    // Secure host check for "x.ai" (Grok)
     const supportsThink = backendLower === 'grok' ||
                           backendLower === 'ollama' ||
-                          this.client.baseURL?.includes('x.ai');
+                          (this.client.baseURL ? this.isAllowedHost(this.client.baseURL, ['x.ai', 'api.x.ai']) : false);
     if (supportsThink) {
       requestPayload.think = false;
     }
@@ -294,15 +295,16 @@ export class GrokClient {
     const supportsToolChoice = backendLower === 'grok' ||
                                backendLower === 'openai' ||
                                backendLower === 'openrouter' ||
-                               this.client.baseURL?.includes('x.ai') ||
-                               this.client.baseURL?.includes('openai.com') ||
-                               this.client.baseURL?.includes('openrouter.ai');
+                               (this.client.baseURL ? this.isAllowedHost(this.client.baseURL, ['x.ai', 'api.x.ai']) : false) ||
+                               (this.client.baseURL ? this.isAllowedHost(this.client.baseURL, ['openai.com', 'api.openai.com']) : false) ||
+                               (this.client.baseURL ? this.isAllowedHost(this.client.baseURL, ['openrouter.ai', 'api.openrouter.ai']) : false);
     if (this.supportsTools && supportsToolChoice && tools && tools.length > 0) {
       requestPayload.tool_choice = "auto";
     }
 
     // Add search parameters if specified and using Grok API (x.ai)
-    if (searchOptions?.search_parameters && this.client.baseURL?.includes('x.ai')) {
+    if (searchOptions?.search_parameters &&
+        (this.client.baseURL ? this.isAllowedHost(this.client.baseURL, ['x.ai', 'api.x.ai']) : false)) {
       requestPayload.search_parameters = searchOptions.search_parameters;
     }
 
@@ -395,6 +397,19 @@ export class GrokClient {
       role: "user",
       content: query,
     };
+  /**
+   * Returns true if the host part of baseURL matches one of the allowedHosts or a subdomain thereof.
+   */
+  private isAllowedHost(urlString: string, allowedHosts: string[]): boolean {
+    try {
+      const { hostname } = new URL(urlString);
+      return allowedHosts.some(allowedHost =>
+        hostname === allowedHost || hostname.endsWith(`.${allowedHost}`)
+      );
+    } catch (e) {
+      return false;
+    }
+  }
 
     const searchOptions: SearchOptions = {
       search_parameters: searchParameters || { mode: "on" },


### PR DESCRIPTION
Potential fix for [https://github.com/ziquid/zds-ai-cli/security/code-scanning/4](https://github.com/ziquid/zds-ai-cli/security/code-scanning/4)

**How to fix it:**  
Instead of performing a substring check with `.includes()`, the code should parse the URL, extract the hostname, and compare it against a list of allowed hostnames (including any relevant subdomains). The comparison should be done explicitly (e.g., equality or endsWith checks with proper dot separation), to prevent accepting superdomains or attacker-crafted hostnames.

**Detailed description:**  
- In each place where `.includes('openai.com')`, `.includes('openrouter.ai')`, etc., is used to check if a backend matches an expected host, use the `URL` class to parse `this.client.baseURL`.  
- Then, compare the parsed hostname using strict comparison against a whitelist, e.g., `'openai.com'`, `'api.openai.com'`, or use logic like `hostname === 'openai.com' || hostname.endsWith('.openai.com')` to accept subdomains, but not attacker domains.
- Add any necessary imports at the top if they’re not present (for the `URL` global, in Node.js this is safe).
- Replace every affected `.includes()` check on `baseURL` with this pattern.
- Only modify the regions that directly contain the problematic uses.

**Files/regions/lines to change:**  
- In `src/grok/client.ts`, lines 279, 297, 298, 299, and 305 each check for host substrings.
- Add a helper function (within the class or file-local) to encapsulate hostname checking logic.
- At call sites, use that function and ensure safe host matching.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
