### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/src/agent/grok-agent.ts
+++ b/src/agent/grok-agent.ts
@@ -2981,7 +2981,7 @@ Current working directory: ${process.cwd()}`;
           this.emit('backendChange', { backend: state.backend });
           this.emit('modelChange', { model });
         } else {
-          console.warn(`Failed to restore backend: API key not found in environment variable ${state.apiKeyEnvVar}`);
+          console.warn("Failed to restore backend: API key not found in environment.");
         }
       } catch (error) {
         console.warn(`Failed to restore backend configuration:`, error);


### PR DESCRIPTION
Potential fix for [https://github.com/ziquid/zds-ai-cli/security/code-scanning/3](https://github.com/ziquid/zds-ai-cli/security/code-scanning/3)

To fix the problem, we should avoid logging the environment variable name used to store sensitive data such as API keys. Instead, the log message should be more generic, indicating that the API key could not be found without specifying which environment variable was searched.  
- In `src/agent/grok-agent.ts`, line 2984, update the log statement to avoid including `${state.apiKeyEnvVar}` directly in the output.
- A suitable replacement is:  
  - `"Failed to restore backend: API key not found in environment."`  
- No further imports or methods are needed.
- Only the relevant line should be changed; preserve logging functionality for troubleshooting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
