### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/tools/image-tool.ts
+++ b/src/tools/image-tool.ts
@@ -202,8 +202,15 @@ export class ImageTool implements ToolDiscovery {
       // Build command using joycaption
       let command = `joycaption '${filename.replace(/'/g, "'\\''")}'`;
 
+      let sanitizationWarning: string | undefined;
       if (prompt) {
-        command += ` --prompt "${prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+        // Sanitize prompt: allow only alphanumeric, spaces, periods, commas, dashes, and asterisks
+        const sanitized = prompt.replace(/[^a-zA-Z0-9 .,\-*]/g, '');
+        if (sanitized !== prompt) {
+          sanitizationWarning = `Prompt was sanitized from "${prompt}" to "${sanitized}"`;
+          console.warn(`Warning: Prompt contained invalid characters and was sanitized. Original: "${prompt}", Sanitized: "${sanitized}"`);
+        }
+        command += ` --prompt "${sanitized}"`;
       }
 
       try {
@@ -225,7 +232,8 @@ export class ImageTool implements ToolDiscovery {
         return {
           success: true,
           output: caption,
-          displayOutput: `Caption: ${caption}`
+          displayOutput: `Caption: ${caption}`,
+          ...(sanitizationWarning && { warning: sanitizationWarning })
         };
       } catch (error: any) {
         // Extract error details

--- a/src/tools/image-tool.ts
+++ b/src/tools/image-tool.ts
@@ -203,7 +203,7 @@ export class ImageTool implements ToolDiscovery {
       let command = `joycaption '${filename.replace(/'/g, "'\\''")}'`;
 
       if (prompt) {
-        command += ` --prompt "${prompt.replace(/"/g, '\\"')}"`;
+        command += ` --prompt "${prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
       }
 
       try {


### PR DESCRIPTION
Potential fix for [https://github.com/ziquid/zds-ai-cli/security/code-scanning/5](https://github.com/ziquid/zds-ai-cli/security/code-scanning/5)

To fix the problem, we must ensure that any backslash characters in `prompt` are also escaped—by replacing every occurrence of `\` with `\\` *before* escaping double quotes. The safest, recommended approach is to perform backslash escaping first, then escape double quotes, i.e., `prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"')`. This will ensure that any backslashes in the user-controlled string are rendered literally in the shell command. The code modification applies to line 206 in `src/tools/image-tool.ts`. No new imports are required, and core functionality is unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
