### PR TITLE
Fix trufflehog action input parameter names

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,5 +33,5 @@ jobs:
       uses: trufflesecurity/trufflehog@v3.90.1
       with:
         path: ./
-        baseRef: ${{ github.event.pull_request.base.ref || github.ref }}
-        headRef: ${{ github.event.pull_request.head.ref || github.sha }}
+        base: ${{ github.event.pull_request.base.ref || github.ref }}
+        head: ${{ github.event.pull_request.head.ref || github.sha }}


### PR DESCRIPTION
Changed baseRef to base and headRef to head to match the valid input names for trufflesecurity/trufflehog action.  Resolves GitHub Actions workflow warning about unexpected inputs.

## What does this PR do?

Describe your changes here.

Fixes #

## Checklist

- [ ] I tested my changes
- [ ] I reviewed my own code