### PR TITLE
Remove unsupported base/head parameters from trufflehog action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,5 +33,3 @@ jobs:
       uses: trufflesecurity/trufflehog@v3.90.1
       with:
         path: ./
-        base: ${{ github.event.pull_request.base.ref || github.ref }}
-        head: ${{ github.event.pull_request.head.ref || github.sha }}


### PR DESCRIPTION
Removed the base and head parameters from the trufflesecurity/trufflehog action configuration.  These parameters were causing workflow warnings and are not needed for the basic secret scanning functionality.

## What does this PR do?

Describe your changes here.

Fixes #

## Checklist

- [ ] I tested my changes
- [ ] I reviewed my own code