### PR TITLE
Add missing js-yaml runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "prompts": "^2.4.2",
         "react": "^19.0.0",
         "ripgrep-node": "^1.0.0",
-        "tiktoken": "^1.0.22"
+        "tiktoken": "^1.0.22",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "encode-speech.sh": "dist/bin/encode-speech.sh",
@@ -49,7 +50,8 @@
         "jest": "^30.2.0",
         "ts-jest": "^29.4.6",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "@types/js-yaml": "^4.0.9"
       },
       "engines": {
         "bun": ">=1.0.0",
@@ -6385,7 +6387,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8538,6 +8539,11 @@
       "peerDependencies": {
         "zod": "^3.25 || ^4"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "fs-extra": "^11.3.3",
     "ink": "^6.6.0",
     "ink-spawn": "^0.1.4",
+    "js-yaml": "^4.1.1",
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",
     "openai": "^5.23.2",
@@ -86,6 +87,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/jest": "^30.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.19.27",
     "@types/prompts": "^2.4.9",
     "@types/react": "^19.0.0",


### PR DESCRIPTION
## Summary

- add `js-yaml` as a runtime dependency because `settings-manager.ts` imports it at startup
- add `@types/js-yaml` for the TypeScript import
- update the lockfile minimally so the dependency is no longer dev-only

Fixes #17.

## Verification

```sh
npm run typecheck
npm run build
```

I also packed this branch and installed it into a clean temporary npm project:

```sh
npm pack
npm init -y
npm install /path/to/zds-ai-cli-0.2.0-alpha.5.tgz
./node_modules/.bin/zai-cli --help
./node_modules/.bin/zai-cli --version
```

The packed build prints help successfully and `--version` prints `0.2.0-alpha.5`.

For comparison, the currently published `@zds-ai/cli@0.1.10` fails in a clean project with:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'js-yaml' imported from .../node_modules/@zds-ai/cli/dist/utils/settings-manager.js
```

## Note

`npm test -- --runInBand` still has an existing unrelated failure in `tests/tool-call-ordering.test.ts` where `stripFn` is not a function. This PR does not touch that code path.
